### PR TITLE
Update sectiontext questions to display on mobile.

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -162,7 +162,9 @@ class mobile {
                         if ($question->supports_mobile()) {
                             $pagequestions[] = $question->mobile_question_display($qnum, $questionnaire->autonum);
                             $responses = array_merge($responses, $question->get_mobile_response_data($response));
-                            $qnum++;
+                            if ($question->is_numbered()) {
+                                $qnum++;
+                            }
                         }
                     }
                     $data['prevpage'] = 0;
@@ -265,8 +267,10 @@ class mobile {
                 if (($response !== null) && isset($response->answers[$questionid])) {
                     $responses = array_merge($responses, $question->get_mobile_response_data($response));
                 }
+                if ($question->is_numbered()) {
+                    $qnum++;
+                }
             }
-            $qnum++;
         }
 
         return ['pagequestions' => $pagequestions, 'responses' => $responses];

--- a/classes/question/pagebreak.php
+++ b/classes/question/pagebreak.php
@@ -102,4 +102,12 @@ class pagebreak extends question {
     public function mobile_question_display($qnum, $autonum = false) {
         return false;
     }
+
+    /**
+     * Override and return false if a number should not be rendered for this question in any context.
+     * @return bool
+     */
+    public function is_numbered() {
+        return false;
+    }
 }

--- a/classes/question/question.php
+++ b/classes/question/question.php
@@ -495,6 +495,14 @@ abstract class question {
     }
 
     /**
+     * Override and return false if a number should not be rendered for this question in any context.
+     * @return bool
+     */
+    public function is_numbered() {
+        return true;
+    }
+
+    /**
      * True if the question supports feedback and has valid settings for feedback. Override if the default logic is not enough.
      * @return bool
      */

--- a/classes/question/sectiontext.php
+++ b/classes/question/sectiontext.php
@@ -60,6 +60,44 @@ class sectiontext extends question {
     }
 
     /**
+     * True if question provides mobile support.
+     * @return bool
+     */
+    public function supports_mobile() {
+        return true;
+    }
+
+    /**
+     * Display on mobile.
+     *
+     * @param $qnum
+     * @param bool $autonum
+     */
+    public function mobile_question_display($qnum, $autonum = false) {
+        $options = ['noclean' => true, 'para' => false, 'filter' => true,
+            'context' => $this->context, 'overflowdiv' => true];
+        $mobiledata = (object)[
+            'id' => $this->id,
+            'name' => $this->name,
+            'type_id' => $this->type_id,
+            'length' => $this->length,
+            'content' => format_text(file_rewrite_pluginfile_urls($this->content, 'pluginfile.php', $this->context->id,
+                'mod_questionnaire', 'question', $this->id), FORMAT_HTML, $options),
+            'content_stripped' => strip_tags($this->content),
+            'required' => false,
+            'deleted' => $this->deleted,
+            'response_table' => $this->responsetable,
+            'fieldkey' => $this->mobile_fieldkey(),
+            'precise' => $this->precise,
+            'qnum' => '',
+            'errormessage' => get_string('required') . ': ' . $this->name
+        ];
+
+        $mobiledata->issectiontext = true;
+        return $mobiledata;
+    }
+
+    /**
      * True if question type supports feedback scores and weights. Same as supports_feedback() by default.
      */
     public function supports_feedback_scores() {
@@ -79,6 +117,14 @@ class sectiontext extends question {
      */
     public function question_template() {
         return 'mod_questionnaire/question_sectionfb';
+    }
+
+    /**
+     * Override and return false if a number should not be rendered for this question in any context.
+     * @return bool
+     */
+    public function is_numbered() {
+        return false;
     }
 
     /**

--- a/classes/questions_form.php
+++ b/classes/questions_form.php
@@ -146,7 +146,7 @@ class questions_form extends \moodleform {
                 redirect($CFG->wwwroot.'/mod/questionnaire/questions.php?id='.$questionnaire->cm->id);
             }
 
-            if ($tid != QUESPAGEBREAK && $tid != QUESSECTIONTEXT) {
+            if ($question->is_numbered()) {
                 $qnum++;
             }
 
@@ -330,12 +330,10 @@ class questions_form extends \moodleform {
                 $mform->addElement('static', 'qdepend_' . $question->id, '', $dependencies);
             }
 
-            if ($tid != QUESPAGEBREAK) {
-                if ($tid != QUESSECTIONTEXT) {
+            if ($question->is_numbered()) {
                     $qnumber = '<div class="qn-info"><h2 class="qn-number">'.$qnum.'</h2></div>';
-                } else {
+            } else {
                     $qnumber = '';
-                }
             }
 
             if ($this->moveq && $pos < $moveqposition) {

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -1323,7 +1323,7 @@ class questionnaire {
                     $this->renderer->render_progress_bar($section, $this->questionsbysec));
         }
         foreach ($this->questionsbysec[$section] as $questionid) {
-            if ($this->questions[$questionid]->type_id != QUESSECTIONTEXT) {
+            if ($this->questions[$questionid]->is_numbered()) {
                 $i++;
             }
             // Need questionnaire id to get the questionnaire object in sectiontext (Label) question class.
@@ -1615,7 +1615,7 @@ class questionnaire {
                 $page++;
             }
             foreach ($section as $questionid) {
-                if ($this->questions[$questionid]->type_id == QUESSECTIONTEXT) {
+                if (!$this->questions[$questionid]->is_numbered()) {
                     $i--;
                 }
                 if (isset($allqdependants[$questionid])) {
@@ -1848,8 +1848,8 @@ class questionnaire {
 
         if (key_exists($section, $this->questionsbysec)) {
             foreach ($this->questionsbysec[$section] as $questionid) {
-                $tid = $this->questions[$questionid]->type_id;
-                if ($tid != QUESSECTIONTEXT) {
+
+                if ($this->questions[$questionid]->is_numbered()) {
                     $qnum++;
                 }
                 if (!$this->questions[$questionid]->response_complete($formdata)) {
@@ -2910,13 +2910,13 @@ class questionnaire {
             if ($question->type_id == QUESPAGEBREAK) {
                 continue;
             }
-            if ($question->type_id != QUESSECTIONTEXT) {
+            if ($question->is_numbered()) {
                 $qnum++;
             }
             if (!$pdf) {
                 $this->page->add_to_page('responses', $this->renderer->container_start('qn-container'));
                 $this->page->add_to_page('responses', $this->renderer->container_start('qn-info'));
-                if ($question->type_id != QUESSECTIONTEXT) {
+                if ($question->is_numbered()) {
                     $this->page->add_to_page('responses', $this->renderer->heading($qnum, 2, 'qn-number'));
                 }
                 $this->page->add_to_page('responses', $this->renderer->container_end()); // End qn-info.
@@ -2928,7 +2928,7 @@ class questionnaire {
             }
             if ($pdf) {
                 $response = new stdClass();
-                if ($question->type_id != QUESSECTIONTEXT) {
+                if ($question->is_numbered()) {
                     $response->qnum = $qnum;
                 }
                 $response->qcontent = format_text(file_rewrite_pluginfile_urls($question->content, 'pluginfile.php',


### PR DESCRIPTION
Also a small refactor for clarity: The question class now has an is_numbered() method (default true) that can be overridden to control whether a number is displayed for the question in any context. Replaced some checks for specific question types with checks for is_numbered().

https://aprende.atlassian.net/browse/LMSDEV-4967